### PR TITLE
Switching over 'which' calls for 'java -version'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ SPLAT is being developed and tested on 64-bit Ubuntu 15.10 with Python 3.4.3. Mi
 * Python 3.4 or Later
 * NLTK 3.1 or Later
 * Java (for the Berkeley Parser)
+* NLTK packages `brown`, `stopwords`, `names`, and `cmudict`
+
 
 - - - -
 ## Installation

--- a/splat/__init__.py
+++ b/splat/__init__.py
@@ -115,7 +115,7 @@ except ImportError:
         print("Hmm... I couldn't install matplotlib for you. You probably don't have root privileges. I suggest running"
               "this command:\n\tsudo pip3 install matplotlib")
 
-java_status = subprocess.call(["which", "java"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+java_status = subprocess.call(["java", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 if java_status != 0:
     print("Java is not installed on your system. Java needs to be installed in order for me to do any part-of-speech"
           "tagging.\n\nPlease install java and try again.")

--- a/splat/splat
+++ b/splat/splat
@@ -188,7 +188,7 @@ def check_dependencies():
             print("Hmm... I couldn't install matplotlib for you. You probably don't have root privileges. I suggest"
                   "running this command:\n\tsudo pip3 install matplotlib")
 
-    java_status = subprocess.call(["which", "java"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    java_status = subprocess.call(["java", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if java_status != 0:
         print("Java is not installed on your system. Java needs to be installed in order for me to do any"
               "part-of-speech tagging.\n\nPlease install java and try again.")


### PR DESCRIPTION
Enables SPLAT to run on non-unix systems